### PR TITLE
[PAYG-524] Deprecate repo in favour of truelayer-signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Paydirect - Request signing & verification examples
 
+## ⚠️ Deprecated ⚠️
+> **`X-Tl-Signature` headers have been deprecated in favour of "v2" `Tl-Signature` headers.**
+>
+> **Go to https://github.com/TrueLayer/truelayer-signing for multi-language signing libraries & examples.**
+
 This repository provides a collection of code samples illustrating how to perform request signing for
 [Payouts API](https://docs.truelayer.com/#payouts-api-v1) using different programming languages.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Paydirect - Request signing & verification examples
 
 ## ⚠️ Deprecated ⚠️
-> **`X-Tl-Signature` headers have been deprecated in favour of "v2" `Tl-Signature` headers.**
+> **`X-Tl-Signature` headers have been deprecated in favour of "v2" `Tl-Signature` full request signature headers.**
 >
 > **Go to https://github.com/TrueLayer/truelayer-signing for multi-language signing libraries & examples.**
 


### PR DESCRIPTION
`X-Tl-Signature` headers have been deprecated in favour of "v2" `Tl-Signature` full request signature headers.

Clients should go to https://github.com/TrueLayer/truelayer-signing for multi-language signing libraries & examples. And we should make improvements there to benefit a wider base in a more maintainable way.